### PR TITLE
fix mistakes in frost protocol description

### DIFF
--- a/src/threshold-ecdsa/chapter.md
+++ b/src/threshold-ecdsa/chapter.md
@@ -11,8 +11,8 @@ In this chapter, we give an overview of threshold signatures and describe the th
 
 - Finally, we briefly specify our instatiation and analyse the security for the threshold ECDSA construction of Canetti et al using  **secp256k1** parameters and FROST threshold signature construction using **ed25519** and **sr25519** parameters as follows:
 
-    - In [Threhold signature for secp256k1](./intended-implementation/threshold-ecdsa-from-secp256k1.md), we discuss and analyse the security of the threshold ECDSA signature of Canneti et al. when instatiated using the parameters of **secp256k1**.
+    - In [Threhold signature for secp256k1](./intended-implementation/threshold-ecdsa-for-secp256k1.md), we discuss and analyse the security of the threshold ECDSA signature of Canneti et al. when instatiated using the parameters of **secp256k1**.
 
-    - In  [Threhold signature for ed25519](./intended-implementation/threshold-ecdsa-from-ed25519.md) we discuss and analyse the security of the FROST threshold signature when instatiated using the parameters of **ed25519**.
+    - In  [Threhold signature for ed25519](./intended-implementation/threshold-ecdsa-for-ed25519.md) we discuss and analyse the security of the FROST threshold signature when instatiated using the parameters of **ed25519**.
 
-    - In [Threhold signature for sr25519](./intended-implementation/threshold-ecdsa-from-sr-25519.md) we discuss and analyse the security of the FROST threshold signature when instatiated using the parameters of **sr25519**.
+    - In [Threhold signature for sr25519](./intended-implementation/threshold-ecdsa-for-sr-25519.md) we discuss and analyse the security of the FROST threshold signature when instatiated using the parameters of **sr25519**.

--- a/src/threshold-ecdsa/frost-construction/introduction.md
+++ b/src/threshold-ecdsa/frost-construction/introduction.md
@@ -2,7 +2,7 @@
 
 In this section we briefly describe the FROST threshold Schnorr protocol in {{#cite KG20}}, in which we assume that the readers have some familiarity to Schnorr signature scheme. Recall that the ordinary Schnorr signature scheme, the signature \\(\sigma=(R,z)\\) of a message \\(M\\) is generated as follow
 
-$$R=g^r,\ c=\mathsf{H}(R||\mathsf{pk}||M)\ \text{and}\ z=c+r\cdot sk$$
+$$R=g^r,\ c=\mathsf{H}(R||\mathsf{pk}||M)\ \text{and}\ z=r+c\cdot sk$$
 
 where \\(r \leftarrow \mathbb{Z}_p\\) and \\(sk\\) is the signer's secret key. Note that the EdDSA signature scheme also produces the signature with the exact form above, with the **only difference** is that the nonce \\(r\\) is produced deterministically.  FROST aims to provide a valid Schnorr signature (as well as EdDSA signature) of \\(M\\) above via a threshold manner. Compared to its threshold ECDSA counterpart, the FROST threshold Schnorr signature is much simplier, has much less features to describe and analyse.  We now move to the actual construction of FROST and describe it.  
 

--- a/src/threshold-ecdsa/frost-construction/sign.md
+++ b/src/threshold-ecdsa/frost-construction/sign.md
@@ -17,4 +17,3 @@ In this section, we describe the signing process of the protocol. For any set \\
 
 6. For each \\(i\\), participants check if \\(R=\prod_{i\in S}R_i\\) and \\(g_i=R_i\mathsf{pk_i}^{c \lambda_{i,S}}\\). If any check fails, report the misbehaving \\(P_i\\) and the protocol is aborted. Otherwise, compute \\(z=\sum_{i \in S}z_i\\) and returns \\(\sigma=(R,z)\\).
 
-For abort identification, there are 3 instances that the protocol can abort in the signing protocol.

--- a/src/threshold-ecdsa/frost-construction/verify.md
+++ b/src/threshold-ecdsa/frost-construction/verify.md
@@ -11,4 +11,4 @@ Recall that the verification algorithm in threshold Schnorr remain identical to 
 
 3. Check if \\(R'=R\\). If the check passes, return \\(1\\), otherwise return \\(0\\).
 
-One can see that, if \\((R,z)\\) is a valid Schnorr signature scheme, which has the form \\(R=g^r, c=\mathsf{H}(R||\mathsf{pk}||M)\\) and \\(z=r+c \cdot \mathsf{sk})\\), then the verification algorithm above returns \\(1\\) since \\(R'=g^{z-\mathsf{sk}c}=g^r=R\}=\\). The converse direction also holds, i.e, if the verify algorithm above return \\(1\\), then \\((R,c,z)\\) must be  a valid Schnorr signature which have the form above.
+One can see that, if \\((R,z)\\) is a valid Schnorr signature scheme, which has the form \\(R=g^r, c=\mathsf{H}(R||\mathsf{pk}||M)\\) and \\(z=r+c \cdot \mathsf{sk})\\), then the verification algorithm above returns \\(1\\) since \\(R'=g^{z-\mathsf{sk}\cdot c}=g^r=R\\). The converse direction also holds, i.e, if the verify algorithm above return \\(1\\), then \\((R,c,z)\\) must be  a valid Schnorr signature which have the form above.


### PR DESCRIPTION
This pull request fix mistakes in the description of the frost protocol. It also correct the URL links in the overview chapter.