### PR TITLE
Fix mathjax rendering error for symbol O

### DIFF
--- a/src/isogeny-based-crypto/supersingular-isogeny-graph/background/elliptic-curve.md
+++ b/src/isogeny-based-crypto/supersingular-isogeny-graph/background/elliptic-curve.md
@@ -2,8 +2,8 @@
 
 #### Definition
 Let \\(K\\) be a field. An **elliptic curve** \\(E\\) is a plane curve defined over the field \\(K\\) as follows:
-$$E(K)=\\{y^2=x^3+ax+b : (x,y) \in K^2\\} \cup \\{\mathcal{O}\\}$$
-where \\((a,b) \in K^2\\). The point \\(\mathcal{O}\\) is called the infinity point of the curve. The set \\(E(K)\\) forms an abelian group with identity element \\(\mathcal{O}\\).
+$$E(K)=\\{y^2=x^3+ax+b : (x,y) \in K^2\\} \cup \\{O\\}$$
+where \\((a,b) \in K^2\\). The point \\(O\\) is called the infinity point of the curve. The set \\(E(K)\\) forms an abelian group with identity element \\(O\\).
 
 In addition, we need the curve to have no cusps, self-intersections, or isolated points. Algebraically, this can be defined by the condition \\(4a^3+27b^2 \neq 0\\) in the field \\(K\\).
 
@@ -11,6 +11,6 @@ The **\\(j-\\) invariant** of an elliptic curve is defined to be \\(-1728\frac{4
 
 The **endomorphism ring** of \\(E\\) is denoted \\(End(E)\\). The structure of \\(End(E)\\) can be found in Chapter 3.9 of Silverman's book.
 
-For an integer \\(n\\), we define \\(E[n]=\\{(x,y) \in E(K) | n*(x,y)=\mathcal{O}\\}\\)
+For an integer \\(n\\), we define \\(E[n]=\\{(x,y) \in E(K) | n*(x,y)=O\\}\\)
 
 Over a field \\(\mathbb{F}_p\\), there are two types of curves: **Ordinary** and **Supersingular**, based on the set \\(E[p]\\). We are interested in studying Supersingular curves, since the isogeny graph on these curves has nice structure and properties. 

--- a/src/isogeny-based-crypto/supersingular-isogeny-graph/background/isogeny.md
+++ b/src/isogeny-based-crypto/supersingular-isogeny-graph/background/isogeny.md
@@ -2,7 +2,7 @@
 
 #### Definition
 
-[{{#cite Was08}}, Chapter XII.1] Let \\(E_1:y^2=x^3+a_1x+b_1\\) and \\(E_2:y^2=x^3+a_2x+b_2\\) be elliptic curves over a field \\(K\\). An **isogeny** from \\(E_1\\) to \\(E_2\\) is a nonconstant homorphism \\(\alpha:E_1 \rightarrow E_2\\) that is given by rational functions. 
+[{{#cite Was08}}, Chapter XII.1] Let \\(E_1:y^2=x^3+a_1x+b_1\\) and \\(E_2:y^2=x^3+a_2x+b_2\\) be elliptic curves over a field \\(K\\). An **isogeny** from \\(E_1\\) to \\(E_2\\) is a nonconstant homorphism \\(\alpha:E_1 \rightarrow E_2\\) that is given by rational functions such that \\(\alpha(O)=O\\). 
 
 This means \\(\alpha(P+Q)=\alpha(P)+\alpha(Q)\\) for all \\(P,Q \in E_1\\) and there exists rational functions \\(P, Q\\) such that if \\(\alpha(x_1, y_1)=(P(x_1, y_1),Q(x_1, y_1))\\).
 

--- a/src/isogeny-based-crypto/supersingular-isogeny-graph/background/supersingular-elliptic-curve.md
+++ b/src/isogeny-based-crypto/supersingular-isogeny-graph/background/supersingular-elliptic-curve.md
@@ -2,11 +2,11 @@
 
 #### Definition
 
-Let \\(p\\) is a prime and let \\(q\\) be a power of \\(p\\). Let \\(E\\) be an elliptic curve over \\(\mathbb{F}_q\\). If \\(E[p]=\mathcal{O}\\), then \\(E\\) is a **Supersingular elliptic curve**, if \\(E[p]=\mathbb{Z}/p\mathbb{Z}\\) then \\(E\\) is an **Ordinary elliptic curve**.
+Let \\(p\\) is a prime and let \\(q\\) be a power of \\(p\\). Let \\(E\\) be an elliptic curve over \\(\mathbb{F}_q\\). If \\(E[p]=O\\), then \\(E\\) is a **Supersingular elliptic curve**, if \\(E[p]=\mathbb{Z}/p\mathbb{Z}\\) then \\(E\\) is an **Ordinary elliptic curve**.
 
 #### Example
 
-For \\(p=3\\), the curve \\(E: y^2=x^3-x\\) is supersingular over the field \\(\bar{F}_3\\). [Here](https://math.stackexchange.com/questions/3607389/find-all-points-order-3-on-an-elliptic-curve) we see that \\([3]*(x,y)=\mathcal{O}\\) for \\((x,y) \neq \mathcal{O}\\) if and only if \\(3x^4-6x^2-1=0\\), but such \\(x\\) does not exist since \\(\bar{F}_3\\) has characteristic \\(3\\). Thus \\(E[3]=\mathcal{O}\\)
+For \\(p=3\\), the curve \\(E: y^2=x^3-x\\) is supersingular over the field \\(\bar{F}_3\\). [Here](https://math.stackexchange.com/questions/3607389/find-all-points-order-3-on-an-elliptic-curve) we see that \\([3]*(x,y)=O\\) for \\((x,y) \neq O\\) if and only if \\(3x^4-6x^2-1=0\\), but such \\(x\\) does not exist since \\(\bar{F}_3\\) has characteristic \\(3\\). Thus \\(E[3]=O\\)
 
 #### Properties
 

--- a/src/isogeny-based-crypto/supersingular-isogeny-graph/graph/application.md
+++ b/src/isogeny-based-crypto/supersingular-isogeny-graph/graph/application.md
@@ -7,6 +7,6 @@ Supersingular Isogeny Graph has applications in both mathematics and cryptograph
     1. The endomorphism ring computation problem: Given \\(p\\) and a
 supersingular \\(j\\)-invariant \\(j\\), compute the endomorphism ring of \\(E(j)\\) {{#cite EHLMP18}}.
     1. The Deuring correspondence problem: Given a maximal order    
-\\(\mathcal{O} \in B_{p,\inf}\\), return a supersingular j-invariant such that the endomorphism ring \\(E(j)\\) is isomorphic to \\(\mathcal{O}\\) {{#cite EHLMP18}}.
+\\(A \in B_{p,\inf}\\), return a supersingular j-invariant such that the endomorphism ring \\(E(j)\\) is isomorphic to \\(A\\) {{#cite EHLMP18}}.
 
 1. **In cryptography** Supersingular Isogeny Graph is used in encryption scheme {{#cite MOT20}}, signature scheme {{#cite SKLPW20}}, hash function {{#cite CGL06}}, verifiable delay function {{#cite LMPS19}}. These schemes are secure against the attack on SIKE.


### PR DESCRIPTION
This PR fixes mathjax rendering error for symbol O by replacing \mathcal{O} with O.